### PR TITLE
declared combined_influxkey in the combined-flux dashboard as variable

### DIFF
--- a/frontend/grafana/dashboards/template-swift-maxi.json
+++ b/frontend/grafana/dashboards/template-swift-maxi.json
@@ -813,7 +813,7 @@
             "params": [
               {
                 "key": "influx_key",
-                "value": "combined_influxkey"
+                "value": "${combined_influxkey}"
               },
               {
                 "key": "start",


### PR DESCRIPTION
one of the influxkeys for combined flux was not declared as variable. This caused an error as "combined_influxkey" is no correct key in the influxDB