### PR TITLE
implemented fastapi v0.121.2 (newest version) and deleted starlette version (according to fastapi documentation)

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -11,7 +11,7 @@ click==8.1.8
 colorama==0.4.6
 dnspython==2.7.0
 dotenv==0.9.9
-fastapi==0.116.2
+fastapi==0.121.2
 h11==0.16.0
 html5lib==1.1
 idna==3.10
@@ -39,7 +39,6 @@ setuptools==78.1.1
 six==1.17.0
 sniffio==1.3.1
 soupsieve==2.8
-starlette==0.47.2
 typing_extensions==4.12.2
 tzdata==2025.1
 tzlocal==5.3.1


### PR DESCRIPTION
Updated fastapi version to v0.121.2 and deleted fixed starlette version. This should avoid O(n^2) vunerabilities from starlette