### PR TITLE
corrected download paths for combined flux

### DIFF
--- a/frontend/grafana/dashboards/template-swift-maxi.json
+++ b/frontend/grafana/dashboards/template-swift-maxi.json
@@ -774,7 +774,7 @@
         {
           "targetBlank": true,
           "title": "Download data",
-          "url": "http://backend:8000/download/combined_influxkey?start=${__from:date}&end=${__to:date}"
+          "url": "http://backend:8000/download/${combined_influxkey}?start=${__from:date}&end=${__to:date}"
         }
       ],
       "options": {
@@ -2734,7 +2734,7 @@
             {
               "targetBlank": true,
               "title": "Download data",
-              "url": "http://backend:8000/download/combined_influxkey?start=${__from:date}&end=${__to:date}"
+              "url": "http://backend:8000/download/${combined_influxkey}?start=${__from:date}&end=${__to:date}"
             }
           ],
           "options": {


### PR DESCRIPTION
declared combined_influxkey in the panel downloadlink from grafana as variable -> is now filled with the corresponding influxkey from the mongoDB. Download works now