### PR TITLE
safety timestamp is now 1

### DIFF
--- a/backend/download.py
+++ b/backend/download.py
@@ -118,7 +118,9 @@ def download_all_data_swift_maxi(url:str, telescope:str) -> pd.DataFrame | None:
                 ]
             df['UTC TIME'] = get_utc_time(df['TIME'])
             df["TIME"] = df["TIME"].astype(int)
+            logging.debug(f"Maximum Timestamp in MJD:{df['TIME'].max()}")
             logging.debug(f"Download complete from {url} for {telescope}")
+            
             return df       
     else:
             logging.error(f"Failed to download data from {url}. Status code: {response.status_code}. Skipping download.")
@@ -154,6 +156,7 @@ def download_all_data_fermi(url:str, temp_dir) -> pd.DataFrame | None:
         df['UTC TIME'] = get_utc_time(df['PSRTIME'])
         df.columns = ['TIME', 'FLUX 12-50', 'ERROR 12-50', 'UTC TIME']
         df["TIME"] = df["TIME"].astype(int)
+        logging.debug(f"Maximum Timestamp in MJD:{df['TIME'].max()}")
         logging.debug(f"Download complete from {url} for fermi")
         return df
     else:
@@ -174,7 +177,7 @@ def filter_times(df: pd.DataFrame, source, telescope) -> pd.DataFrame | None:
         logging.error(f"Unsupported telescope: {telescope}. Skipping time filtering")
         return None
     last_timestamp = source[telescope]['last_timestamp']
-    safety_window_days = 3
+    safety_window_days = 1
     cutoff = last_timestamp - safety_window_days
     logging.debug(
         f"Filtering data for {source['integral_name']} from {telescope}. "

--- a/backend/download.py
+++ b/backend/download.py
@@ -119,6 +119,7 @@ def download_all_data_swift_maxi(url:str, telescope:str) -> pd.DataFrame | None:
             df['UTC TIME'] = get_utc_time(df['TIME'])
             df["TIME"] = df["TIME"].astype(int)
             logging.debug(f"Maximum Timestamp in MJD:{df['TIME'].max()}")
+            logging.debug(f"Today's Timestamp in MJD: {int(Time.now().mjd)}")
             logging.debug(f"Download complete from {url} for {telescope}")
             
             return df       
@@ -156,7 +157,8 @@ def download_all_data_fermi(url:str, temp_dir) -> pd.DataFrame | None:
         df['UTC TIME'] = get_utc_time(df['PSRTIME'])
         df.columns = ['TIME', 'FLUX 12-50', 'ERROR 12-50', 'UTC TIME']
         df["TIME"] = df["TIME"].astype(int)
-        logging.debug(f"Maximum Timestamp in MJD:{df['TIME'].max()}")
+        logging.debug(f"Maximum Timestamp in MJD: {df['TIME'].max()}")
+        logging.debug(f"Today's Timestamp in MJD: {int(Time.now().mjd)}")
         logging.debug(f"Download complete from {url} for fermi")
         return df
     else:


### PR DESCRIPTION
this should work as only the newest datapoint can be updated in swiftdata. If the bug arises during filtering, this should now show all data up to the latest day